### PR TITLE
add simple dialog menu to launch python scripts

### DIFF
--- a/3dxmas.sh
+++ b/3dxmas.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+DIRECTORY="$(dirname "$0")"
+DIRECTORY="$(cd "$DIRECTORY" && pwd)"
+
+function select_file() {
+    local options=()
+    local file
+    local i=0
+    while read -r file; do
+        options+=("$i" "$file")
+        ((i++))
+    done < <(find "$DIRECTORY" -type f -name "*.py" | sort)
+
+    local cmd=(dialog --menu "Choose file" 22 76 16)
+    local choice
+    while true; do
+        choice=$("${cmd[@]}"  "${options[@]}" 2>&1 >/dev/tty)
+        [[ -z "$choice" ]] && return 0
+        python "${options[$choice*2+1]}"
+    done
+}
+
+select_file


### PR DESCRIPTION
Had a bit of help from my mate @joolswills cause he's a genius.

Here's my reasoning for this: 

N00b such as myself thinks, hey swanky christmas tree. how do I even light it up? 

Finds this cool repo and sees a simple guide:

git clone repo
run bash menu
automatic lights. Magic.

This should hopefully simplify the setup process/usage a bit as it loads the menu dynamically so we don't have to keep recoding it every time a new script is added. Could also have some dependency/error handling if we're ambitious but this is a good simple start. 